### PR TITLE
Replace LaunchQL references with Constructive, update Web2/Web3 to Cloud/Chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
    </a>
    <br>
    <a href="https://github.com/constructive-io/lib-count">
-      <img height="20" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fconstructive-io%2Flib-count%2Fmain%2Foutput%2Fbadges%2Flaunchql_category.json"/>
+      <img height="20" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fconstructive-io%2Flib-count%2Fmain%2Foutput%2Fbadges%2Fconstructive_category.json"/>
    </a>
    <a href="https://github.com/constructive-io/lib-count">
       <img height="20" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fconstructive-io%2Flib-count%2Fmain%2Foutput%2Fbadges%2Fhyperweb_category.json"/>
@@ -811,4 +811,4 @@ Let's build the future, together. 🚀
 
 
 
-<!-- README.md automatically generated on 2026-01-28T11:25:33.656Z from lib-count repository with latest download stats -->
+<!-- README.md automatically generated on 2026-01-28T11:42:16.595Z from lib-count repository with latest download stats -->

--- a/packages/stats-db/src/tasks/npm/npm.gen-readme.ts
+++ b/packages/stats-db/src/tasks/npm/npm.gen-readme.ts
@@ -279,8 +279,8 @@ function generateBadgesSection(repoName: string): string {
   const encodedWeeklyDownloadsUrl = encodeURIComponent(
     `${rawBaseRepoUrl}weekly_downloads.json`
   );
-  const encodedLaunchQlCategoryUrl = encodeURIComponent(
-    `${rawBaseRepoUrl}launchql_category.json`
+  const encodedConstructiveCategoryUrl = encodeURIComponent(
+    `${rawBaseRepoUrl}constructive_category.json`
   );
   const encodedHyperwebCategoryUrl = encodeURIComponent(
     `${rawBaseRepoUrl}hyperweb_category.json`
@@ -303,7 +303,7 @@ function generateBadgesSection(repoName: string): string {
    </a>
    <br>
    <a href="https://github.com/${repoName}">
-      <img height="20" src="https://img.shields.io/endpoint?url=${encodedLaunchQlCategoryUrl}"/>
+      <img height="20" src="https://img.shields.io/endpoint?url=${encodedConstructiveCategoryUrl}"/>
    </a>
    <a href="https://github.com/${repoName}">
       <img height="20" src="https://img.shields.io/endpoint?url=${encodedHyperwebCategoryUrl}"/>

--- a/packages/stats-db/src/tasks/npm/npm.reports.ts
+++ b/packages/stats-db/src/tasks/npm/npm.reports.ts
@@ -538,6 +538,8 @@ async function generateBadges(
     "#01A1FF"
   );
   writeBadgeFile(libCountOutputDir, "constructive_category.json", cloudBadge);
+  // Keep launchql_category.json for backwards compatibility (old npm versions may reference it)
+  writeBadgeFile(libCountOutputDir, "launchql_category.json", cloudBadge);
 
   // Utils category badge
   const utilsBadge = createBadgeJson(

--- a/packages/stats-db/src/tasks/npm/npm.reports.ts
+++ b/packages/stats-db/src/tasks/npm/npm.reports.ts
@@ -538,8 +538,6 @@ async function generateBadges(
     "#01A1FF"
   );
   writeBadgeFile(libCountOutputDir, "constructive_category.json", cloudBadge);
-  // Keep launchql_category.json as an alias for backwards compatibility
-  writeBadgeFile(libCountOutputDir, "launchql_category.json", cloudBadge);
 
   // Utils category badge
   const utilsBadge = createBadgeJson(
@@ -712,7 +710,7 @@ function generateOverviewSection(): string {
 
 Welcome to the official repository for tracking the download counts of Constructive's software. This repository provides detailed statistics on the downloads, helping users and developers gain insights into the usage and popularity of our products.
 
-**the Web:** At the heart of our mission is the synergy between the mature, user-friendly ecosystem of Web2 and the decentralized, secure potential of Web3. We're here to bridge this gap, unlocking real-world applications and the full potential of technology, making the web whole again.
+**the Web:** At the heart of our mission is the synergy between the mature, user-friendly ecosystem of Cloud and the decentralized, secure potential of Chain. We're here to bridge this gap, unlocking real-world applications and the full potential of technology, making the web whole again.
 
 ### Our Projects:
 - **[Hyperweb](https://github.com/hyperweb-io):** Build interchain apps in light speed.


### PR DESCRIPTION
## Summary

This PR updates the badge references and terminology in the lib-count badge generation:

1. **Badge URL reference**: Changed the README badge section to reference `constructive_category.json` instead of `launchql_category.json`
2. **Backwards compatibility**: Both `constructive_category.json` and `launchql_category.json` are still generated (launchql kept for old npm versions that may reference it)
3. **Updated terminology**: Changed "Web2 and Web3" to "Cloud and Chain" in the overview section text

## Updates since last revision

Restored `launchql_category.json` generation for backwards compatibility. The README now references `constructive_category.json`, but both badge files are generated to avoid breaking old references.

## Review & Testing Checklist for Human

- [ ] **Run badge generation** - Execute `pnpm npm:badges` and verify both `constructive_category.json` and `launchql_category.json` are generated in `output/badges/`
- [ ] **Run README generation** - Execute `pnpm npm:readme` and verify the badge section references `constructive_category.json` (not launchql)
- [ ] **Verify Cloud/Chain terminology** - Check that the overview text says "Cloud and Chain" instead of "Web2 and Web3"

**Recommended test plan:**
1. Run `pnpm npm:badges` to regenerate badges
2. Confirm both `output/badges/constructive_category.json` and `output/badges/launchql_category.json` exist
3. Run `pnpm npm:readme` to regenerate the README
4. Verify the README badge section references `constructive_category.json`

### Notes

This is a follow-up to PR #25 which added the Cloud/Chain naming and Constructive badge.

Requested by: Dan Lynch (@pyramation)
Link to Devin run: https://app.devin.ai/sessions/24909f83a9384477867fd49546f53bd3